### PR TITLE
Add ZeroSSL support and provider flags; update ACME client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/artyom/leproxy
 
 require (
 	github.com/artyom/autoflags v1.1.0
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.31.0
 )
 
-go 1.13
+go 1.21


### PR DESCRIPTION
## Summary
- Add support for selecting ACME provider (Let's Encrypt or ZeroSSL) and custom ACME directory URLs
- Add ZeroSSL External Account Binding (EAB) flags (EAB KID and HMAC) and required validation
- Use custom acme.Client when a non-default directory URL is specified
- Improve HTTP listener startup error handling
- Update Go module requirements (golang.org/x/crypto v0.31.0) and Go version to 1.21

## Changes
### CLI / Configuration
- New flags on runArgs:
  - `--provider` (letsencrypt | zerossl) — select ACME provider (default: letsencrypt)
  - `--acme-url` — custom ACME directory URL (overrides provider)
  - `--eab-kid` — External Account Binding Key ID (required for ZeroSSL)
  - `--eab-hmac` — External Account Binding HMAC key (required for ZeroSSL)
- Default provider remains Let's Encrypt unless `--provider=zerossl` or `--acme-url` is provided

### ACME / autocert
- `setupServer` signature extended to accept provider, acmeURL, eabKID, eabHMAC
- If `--acme-url` is provided it is used as the ACME directory URL
- If `--provider=zerossl` the directory URL is set to ZeroSSL's endpoint and the code enforces that an email and EAB credentials are provided
- When a non-default directory URL is used, a custom `acme.Client` is created and assigned to the autocert.Manager
- A minimal EAB handling stub is added with logging and validation; note in-code comments that a full EAB registration (proper JWS signing flow per RFC 8555) should be implemented for production

### Server startup
- HTTP fallback server (for http-01 challenges and redirects) is started in a goroutine and now reports immediate startup errors back to run() via a channel and select timeout instead of calling log.Fatal

### Dependency and build
- go.mod: upgrade golang.org/x/crypto to v0.31.0
- go version set to 1.21

## Files changed
- main.go
  - Added imports: context, golang.org/x/crypto/acme
  - Reworked runArgs flags and default values
  - Extended setupServer to choose provider and configure a custom acme.Client
  - Added HTTP server startup error handling
- go.mod
  - Bumped x/crypto and go version

## Test plan
- Unit / manual tests:
  - Start the server with default settings (no provider flags) and confirm certificates are obtained from Let's Encrypt
    - e.g. ./leproxy --cacheDir=/tmp/leproxy-cache --conf=mapping.yml
  - Start with ZeroSSL:
    - ./leproxy --provider=zerossl --email=you@example.com --eab-kid=<KID> --eab-hmac=<HMAC> --cacheDir=/tmp/leproxy-cache --conf=mapping.yml
    - Verify startup logs show Using ACME provider: zerossl and the configured directory URL
    - Verify certificates are requested and cached
  - Test a custom ACME directory URL via `--acme-url` and confirm the client uses that directory and logs it
  - Test HTTP server startup failure (bind to an occupied port) to verify run() returns an error instead of exiting the process

## Migration notes / caveats
- ZeroSSL requires External Account Binding (EAB). This change validates presence of EAB flags and logs usage, but the current implementation contains a simplified EAB placeholder: a complete EAB signing/registration flow must be implemented for production use (see RFC 8555 and ZeroSSL developer docs).
- Go toolchain requirement updated: Go 1.21
- Dependency: golang.org/x/crypto v0.31.0

## Follow-ups
- Implement full EAB account registration (proper JWS signing with the HMAC and KID) and integrate with autocert or acme client registration flow
- Add integration tests for different ACME providers and edge cases
- Consider surfacing more diagnostic information and retries for ACME discovery/registration failures


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/186624b8-c0a8-4099-869a-3478a0b7434f